### PR TITLE
Fix Determinate Animation Restarting When Window Became Nil

### DIFF
--- a/Sources/NicoProgressBar.swift
+++ b/Sources/NicoProgressBar.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 //MARK: - NicoProgressBarState
-public enum NicoProgressBarState {
+public enum NicoProgressBarState: Equatable {
     case indeterminate
     case determinate(percentage: CGFloat)
     
@@ -87,6 +87,11 @@ open class NicoProgressBar: UIView {
     
     //MARK: Public API
     public func transition(to newState: NicoProgressBarState, delay: TimeInterval = 0, completion: ((Bool) -> Void)? = nil) {
+        guard self.state != newState else {
+            completion?(false)
+            return
+        }
+
         switch self.state {
             case .indeterminate:
                 moveProgressBarIndicatorToStart()

--- a/Sources/NicoProgressBar.swift
+++ b/Sources/NicoProgressBar.swift
@@ -116,8 +116,7 @@ open class NicoProgressBar: UIView {
             delay: delay,
             options: [.beginFromCurrentState],
             animations: {
-                self.progressBarIndicator.frame = CGRect(x: 0,
-                                                         y: 0,
+                self.progressBarIndicator.frame = CGRect(x: 0, y: 0,
                                                          width: self.bounds.width * percent,
                                                          height: self.bounds.size.height)
             },
@@ -161,8 +160,7 @@ open class NicoProgressBar: UIView {
                     animations: { [weak self] in
                         guard let self = self else { return }
 
-                        self.progressBarIndicator.frame = CGRect(x: 0,
-                                                                 y: 0,
+                        self.progressBarIndicator.frame = CGRect(x: 0, y: 0,
                                                                  width: self.bounds.width * 0.7,
                                                                  height: self.bounds.size.height)
                     })
@@ -173,8 +171,7 @@ open class NicoProgressBar: UIView {
                     animations: { [weak self] in
                         guard let self = self else { return }
 
-                        self.progressBarIndicator.frame = CGRect(x: self.bounds.width,
-                                                                 y: 0,
+                        self.progressBarIndicator.frame = CGRect(x: self.bounds.width, y: 0,
                                                                  width: self.bounds.width * 0.3,
                                                                  height: self.bounds.size.height)
                     })

--- a/Sources/NicoProgressBar.swift
+++ b/Sources/NicoProgressBar.swift
@@ -57,13 +57,8 @@ open class NicoProgressBar: UIView {
         self.init(frame: CGRect.zero)
     }
     
-    open override func didMoveToWindow() {
-        super.didMoveToWindow()
-
-        guard window != nil else {
-            stopIndeterminateAnimation()
-            return
-        }
+    open override func didMoveToSuperview() {
+        super.didMoveToSuperview()
 
         moveProgressBarIndicatorToStart()
         DispatchQueue.main.async {
@@ -71,6 +66,14 @@ open class NicoProgressBar: UIView {
         }
     }
     
+    open override func didMoveToWindow() {
+        super.didMoveToWindow()
+
+        if window == nil {
+            stopIndeterminateAnimation()
+        }
+    }
+
     //MARK: Setup
     private func setupViews() {
         self.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/NicoProgressBar.swift
+++ b/Sources/NicoProgressBar.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 //MARK: - NicoProgressBarState
-public enum NicoProgressBarState: Equatable {
+public enum NicoProgressBarState {
     case indeterminate
     case determinate(percentage: CGFloat)
     
@@ -90,11 +90,6 @@ open class NicoProgressBar: UIView {
     
     //MARK: Public API
     public func transition(to newState: NicoProgressBarState, delay: TimeInterval = 0, completion: ((Bool) -> Void)? = nil) {
-        guard self.state != newState else {
-            completion?(false)
-            return
-        }
-
         switch self.state {
             case .indeterminate:
                 moveProgressBarIndicatorToStart()

--- a/Sources/NicoProgressBar.swift
+++ b/Sources/NicoProgressBar.swift
@@ -111,9 +111,17 @@ open class NicoProgressBar: UIView {
     
     // MARK: Private
     private func animateProgress(toPercent percent: CGFloat, delay: TimeInterval = 0, completion: ((Bool) -> Void)? = nil) {
-        UIView.animate(withDuration: determinateAnimationDuration, delay: delay, options: [.beginFromCurrentState], animations: {
-            self.progressBarIndicator.frame = CGRect(x: 0, y: 0, width: self.bounds.width * percent, height: self.bounds.size.height)
-        }, completion: completion)
+        UIView.animate(
+            withDuration: determinateAnimationDuration,
+            delay: delay,
+            options: [.beginFromCurrentState],
+            animations: {
+                self.progressBarIndicator.frame = CGRect(x: 0,
+                                                         y: 0,
+                                                         width: self.bounds.width * percent,
+                                                         height: self.bounds.size.height)
+            },
+            completion: completion)
     }
     
     private func startIndeterminateAnimation(delay: TimeInterval = 0) {
@@ -134,27 +142,47 @@ open class NicoProgressBar: UIView {
     }
     
     private var zeroFrame: CGRect {
-        return CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: 0, height: bounds.size.height))
+        return CGRect(origin: .zero, size: CGSize(width: 0, height: bounds.size.height))
     }
     
     private func runIndeterminateAnimationLoop(delay: TimeInterval = 0) {
         moveProgressBarIndicatorToStart()
         
-        UIView.animateKeyframes(withDuration: indeterminateAnimationDuration, delay: delay, options: [], animations: { [weak self] in
-            guard let strongSelf = self else { return }
-            UIView.addKeyframe(withRelativeStartTime: 0, relativeDuration: strongSelf.indeterminateAnimationDuration/2, animations: { [weak self] in
-                guard let strongSelf = self else { return }
-                strongSelf.progressBarIndicator.frame = CGRect(x: 0, y: 0, width: strongSelf.bounds.width * 0.7, height: strongSelf.bounds.size.height)
-            })
-            UIView.addKeyframe(withRelativeStartTime: strongSelf.indeterminateAnimationDuration/2, relativeDuration: strongSelf.indeterminateAnimationDuration/2, animations: { [weak self] in
-                guard let strongSelf = self else { return }
-                strongSelf.progressBarIndicator.frame = CGRect(x: strongSelf.bounds.width, y: 0, width: strongSelf.bounds.width * 0.3, height: strongSelf.bounds.size.height)
-            })
-        }) { [weak self] _ in
-            guard let strongSelf = self else { return }
+        UIView.animateKeyframes(
+            withDuration: indeterminateAnimationDuration,
+            delay: delay,
+            options: [],
+            animations: { [weak self] in
+                guard let self = self else { return }
 
-            if strongSelf.isIndeterminateAnimationRunning {
-                strongSelf.runIndeterminateAnimationLoop()
+                UIView.addKeyframe(
+                    withRelativeStartTime: 0,
+                    relativeDuration: self.indeterminateAnimationDuration/2,
+                    animations: { [weak self] in
+                        guard let self = self else { return }
+
+                        self.progressBarIndicator.frame = CGRect(x: 0,
+                                                                 y: 0,
+                                                                 width: self.bounds.width * 0.7,
+                                                                 height: self.bounds.size.height)
+                    })
+
+                UIView.addKeyframe(
+                    withRelativeStartTime: self.indeterminateAnimationDuration/2,
+                    relativeDuration: self.indeterminateAnimationDuration/2,
+                    animations: { [weak self] in
+                        guard let self = self else { return }
+
+                        self.progressBarIndicator.frame = CGRect(x: self.bounds.width,
+                                                                 y: 0,
+                                                                 width: self.bounds.width * 0.3,
+                                                                 height: self.bounds.size.height)
+                    })
+        }) { [weak self] _ in
+            guard let self = self else { return }
+
+            if self.isIndeterminateAnimationRunning {
+                self.runIndeterminateAnimationLoop()
             }
         }
     }

--- a/Sources/NicoProgressBar.swift
+++ b/Sources/NicoProgressBar.swift
@@ -56,21 +56,21 @@ open class NicoProgressBar: UIView {
     convenience init() {
         self.init(frame: CGRect.zero)
     }
-    
+
+    open override func willMove(toSuperview newSuperview: UIView?) {
+        super.willMove(toSuperview: newSuperview)
+
+        if newSuperview == nil {
+            stopIndeterminateAnimation()
+        }
+    }
+
     open override func didMoveToSuperview() {
         super.didMoveToSuperview()
 
         moveProgressBarIndicatorToStart()
         DispatchQueue.main.async {
             self.transition(to: self.state)
-        }
-    }
-    
-    open override func didMoveToWindow() {
-        super.didMoveToWindow()
-
-        if window == nil {
-            stopIndeterminateAnimation()
         }
     }
 


### PR DESCRIPTION
If the window became nil for the progress view, it would reset and reanimate the state. This would happen if the progress bar was inside a tableview cell and a new screen got pushed on (you could see it reset to the starting point of the animation when the screen was pushed on top, and then popping the screen would animate the progress bar again as the window changed).

This fix uses the superview class functions to do this in a more elegant way.

I'm not certain if the starting of the animation really should be done in didMoveToWindow instead of just when it's superview changes (feel free to give feedback on that).

I also did some formatting in the animation functions to make it easier to read.