### PR TITLE
Bump Version to 0.2.1

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - NicoProgress (0.1.6)
+  - NicoProgress (0.2.1)
 
 DEPENDENCIES:
   - NicoProgress (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  NicoProgress: bfd8b7d674cc1f194849bac02c603901dd1662bb
+  NicoProgress: 480440cc6266c806712568c8128bd6b61719c43f
 
 PODFILE CHECKSUM: 20ec0e6e1c089398c46468d112532cc343410845
 

--- a/NicoProgress.podspec
+++ b/NicoProgress.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'NicoProgress'
-  s.version          = '0.2.0'
+  s.version          = '0.2.1'
   s.summary          = 'Simple linear progress bar for indeterminate and determinate progress'
   s.description      = <<-DESC
 "A simple material UI progress bar. For indeterminate and linear progress. Supporting both programmatic and storyboard initialization."


### PR DESCRIPTION
PR to bump the version to 0.2.1 once [this PR](https://github.com/CityTransit/NicoProgress/pull/3) is merged.